### PR TITLE
'byte' was spelt as 'bype' so one of the dsi clocks is not found. 

### DIFF
--- a/arch/arm64/boot/dts/vendor/qcom/kona-sde-display.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/kona-sde-display.dtsi
@@ -1342,7 +1342,7 @@
 	qcom,suspend-ulps-enabled;
 	qcom,dsi-select-clocks = "mux_byte_clk0", "mux_pixel_clk0",
 				"src_byte_clk0", "src_pixel_clk0",
-				"shadow_bype_clk0", "shadow_pixel_clk0";
+				"shadow_byte_clk0", "shadow_pixel_clk0";
 	qcom,mdss-dsi-clk-strength = <0xFF>;
 	qcom,mdss-dsi-display-timings {
 		/* 120 Hz */

--- a/drivers/mailbox/msm_qmp.c
+++ b/drivers/mailbox/msm_qmp.c
@@ -978,7 +978,7 @@ static int qmp_mbox_probe(struct platform_device *pdev)
 								mdev->name);
 
 	ret = devm_request_irq(&pdev->dev, mdev->rx_irq_line, qmp_irq_handler,
-		IRQF_TRIGGER_RISING | IRQF_NO_SUSPEND | IRQF_SHARED,
+		IRQF_TRIGGER_RISING | IRQF_SHARED,
 		edge_node->name, mdev);
 	if (ret < 0) {
 		qmp_mbox_remove(pdev);


### PR DESCRIPTION
I don't know if this actually affects anything but there is an error message on boot that it will fix:

[    1.533624] [drm:dsi_display_init] *ERROR* [msm-dsi-error]: failed to get shadow_bype_clk0, rc=-2