### PR TITLE
Arrow 11.0 testing

### DIFF
--- a/arch/arm64/Makefile
+++ b/arch/arm64/Makefile
@@ -55,6 +55,20 @@ else
 KBUILD_CFLAGS	+= -mgeneral-regs-only
 endif
 KBUILD_CFLAGS	+= $(lseinstr) $(brokengasinst) $(compat_vdso)
+
+ifeq ($(CONFIG_ARCH_KONA), y)
+ifeq ($(cc-name),clang)
+KBUILD_CFLAGS   += -mcpu=cortex-a55
+KBUILD_AFLAGS   += -mcpu=cortex-a55
+ifeq ($(CONFIG_LD_IS_LLD), y)
+KBUILD_LDFLAGS  += -mllvm -mcpu=cortex-a55
+endif
+else
+KBUILD_CFLAGS   += -mcpu=cortex-a77.cortex-a55
+KBUILD_AFLAGS   += -mcpu=cortex-a77.cortex-a55
+endif
+endif
+
 KBUILD_CFLAGS	+= -fno-asynchronous-unwind-tables
 KBUILD_CFLAGS	+= $(call cc-disable-warning, psabi)
 KBUILD_AFLAGS	+= $(lseinstr) $(brokengasinst) $(compat_vdso)

--- a/arch/arm64/boot/dts/vendor/qcom/dsi-panel-k11a-38-08-0a-dsc-cmd.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/dsi-panel-k11a-38-08-0a-dsc-cmd.dtsi
@@ -43,8 +43,8 @@
 		qcom,bl-update-flag = "delay_until_first_frame";
 
 		qcom,mdss-dsi-display-timings {
-			timing@0{
-				qcom,mdss-dsi-panel-framerate = <60>;
+			timing@0 {
+				qcom,mdss-dsi-panel-framerate = <120>;
 				qcom,mdss-dsi-panel-width = <1080>;
 				qcom,mdss-dsi-panel-height = <2400>;
 				qcom,mdss-dsi-h-front-porch = <16>;
@@ -124,12 +124,10 @@
 					39 00 00 00 00 00 02 B0 01
 					39 01 00 00 00 00 02 E6 01
 					39 01 00 00 00 00 03 F0 A5 A5
-					/* flicker */
 					39 00 00 00 00 00 03 F0 5A 5A
 					39 00 00 00 00 00 02 B0 08
 					39 00 00 00 00 00 02 D4 05
 					39 01 00 00 00 00 03 F0 A5 A5
-					/* 3.7 Hporch Setting */
 					39 01 00 00 00 00 03 F0 5A 5A
 					39 01 00 00 00 00 03 FC 5A 5A
 					39 00 00 00 00 00 02 B0 16
@@ -147,8 +145,8 @@
 					39 01 00 00 00 00 03 51 00 00             /* Write Display Brightness */
 					/* 5 Display On */
 					05 01 00 00 00 00 02 29 00
-					/* 60hz Frequency Select*/
-					39 01 00 00 00 00 02 60 00];
+					39 01 00 00 00 00 02 60 10
+				];
 				qcom,mdss-dsi-off-command = [
 					05 01 00 00 14 00 02 28 00
 					/* Default Frequency Setting */
@@ -158,7 +156,14 @@
 				qcom,mdss-dsi-off-command-state = "dsi_lp_mode";
 
 				qcom,mdss-dsi-timing-switch-command = [
-					39 01 00 00 09 00 02 60 00];
+					39 00 00 00 00 00 02 60 10
+					39 00 00 00 00 00 03 F0 5A 5A
+					39 00 00 00 00 00 03 FC 5A 5A
+					39 00 00 00 00 00 02 B0 16
+					39 00 00 00 00 00 02 D1 2E
+					39 00 00 00 00 00 03 FC A5 A5
+					39 01 00 00 00 00 03 F0 A5 A5
+				];
 				qcom,mdss-dsi-timing-switch-command-state = "dsi_lp_mode";
 
 				qcom,mdss-dsi-nolp-command = [
@@ -167,7 +172,11 @@
 					39 00 00 00 00 00 02 EE 06
 					39 00 00 00 00 00 02 B0 0B
 					39 00 00 00 00 00 03 D8 59 70
-					39 00 00 00 00 00 02 60 00
+					39 00 00 00 00 00 02 60 10
+					39 00 00 00 00 00 03 FC 5A 5A
+					39 00 00 00 00 00 02 B0 16
+					39 00 00 00 00 00 02 D1 2E
+					39 00 00 00 00 00 03 FC A5 A5
 					39 01 00 00 00 00 02 53 28
 					39 01 00 00 09 00 03 F0 A5 A5
 				];
@@ -181,8 +190,9 @@
 				qcom,mdss-dsc-bit-per-pixel = <8>;
 				qcom,mdss-dsc-block-prediction-enable;
 			};
-			timing@1{
-				qcom,mdss-dsi-panel-framerate = <120>;
+
+			timing@1 {
+				qcom,mdss-dsi-panel-framerate = <60>;
 				qcom,mdss-dsi-panel-width = <1080>;
 				qcom,mdss-dsi-panel-height = <2400>;
 				qcom,mdss-dsi-h-front-porch = <16>;
@@ -199,7 +209,7 @@
 				qcom,mdss-dsi-v-bottom-border = <0>;
 				qcom,mdss-dsi-panel-clockrate = <1100000000>;
 				qcom,mdss-dsi-panel-jitter = <0x5 0x1>;
-				qcom,mdss-mdp-transfer-time-us = <7000>;
+				qcom,mdss-mdp-transfer-time-us = <14000>;
 				qcom,mdss-dsi-on-command = [
 					/* 1 Sleep Out */
 					05 01 00 00 0A 00 02 11 00            /* Sleep Out */
@@ -262,12 +272,10 @@
 					39 00 00 00 00 00 02 B0 01
 					39 01 00 00 00 00 02 E6 01
 					39 01 00 00 00 00 03 F0 A5 A5
-					/* flicker */
 					39 00 00 00 00 00 03 F0 5A 5A
 					39 00 00 00 00 00 02 B0 08
 					39 00 00 00 00 00 02 D4 05
 					39 01 00 00 00 00 03 F0 A5 A5
-					/* 3.7 Hporch Setting */
 					39 01 00 00 00 00 03 F0 5A 5A
 					39 01 00 00 00 00 03 FC 5A 5A
 					39 00 00 00 00 00 02 B0 16
@@ -296,7 +304,14 @@
 				qcom,mdss-dsi-off-command-state = "dsi_lp_mode";
 
 				qcom,mdss-dsi-timing-switch-command = [
-					39 01 00 00 00 00 02 60 10];
+					39 00 00 00 00 00 02 60 00
+					39 00 00 00 00 00 03 F0 5A 5A
+					39 00 00 00 00 00 03 FC 5A 5A
+					39 00 00 00 00 00 02 B0 16
+					39 00 00 00 00 00 02 D1 2E
+					39 00 00 00 00 00 03 FC A5 A5
+					39 01 00 00 0C 00 03 F0 A5 A5
+				];
 				qcom,mdss-dsi-timing-switch-command-state = "dsi_lp_mode";
 
 				qcom,mdss-dsi-nolp-command = [
@@ -305,9 +320,13 @@
 					39 00 00 00 00 00 02 EE 06
 					39 00 00 00 00 00 02 B0 0B
 					39 00 00 00 00 00 03 D8 59 70
-					39 00 00 00 00 00 02 60 10
+					39 00 00 00 00 00 02 60 00
+					39 00 00 00 00 00 03 FC 5A 5A
+					39 00 00 00 00 00 02 B0 16
+					39 00 00 00 00 00 02 D1 2E
+					39 00 00 00 00 00 03 FC A5 A5
 					39 01 00 00 00 00 02 53 28
-					39 01 00 00 09 00 03 F0 A5 A5
+					39 01 00 00 11 00 03 F0 A5 A5
 				];
 				qcom,mdss-dsi-nolp-command-state = "dsi_lp_mode";
 
@@ -334,7 +353,7 @@
 	mi,mdss-dsi-panel-dc-threshold = <440>;
 	mi,mdss-dsi-panel-max-brightness-clone = <8191>;
 	qcom,mdss-dsi-display-timings {
-		timing@0{
+		timing@0 {
 			mi,mdss-dsi-dimmingon-command = [39 01 00 00 00 00 02 53 28];
 			mi,mdss-dsi-dimmingon-command-state = "dsi_hs_mode";
 			mi,mdss-dsi-dimmingoff-command = [39 01 00 00 00 00 02 53 20];
@@ -355,6 +374,10 @@
 				05 01 00 00 00 00 02 28 00
 				39 00 00 00 00 00 03 F0 5A 5A
 				39 00 00 00 00 00 02 60 00
+				39 00 00 00 00 00 03 FC 5A 5A
+				39 00 00 00 00 00 02 B0 16
+				39 00 00 00 00 00 02 D1 2E
+				39 00 00 00 00 00 03 FC A5 A5
 				39 00 00 00 00 00 02 B0 0B
 				39 00 00 00 00 00 03 D8 50 00
 				39 00 00 00 00 00 02 53 22
@@ -365,6 +388,10 @@
 				05 01 00 00 00 00 02 28 00
 				39 00 00 00 00 00 03 F0 5A 5A
 				39 00 00 00 00 00 02 60 00
+				39 00 00 00 00 00 03 FC 5A 5A
+				39 00 00 00 00 00 02 B0 16
+				39 00 00 00 00 00 02 D1 2E
+				39 00 00 00 00 00 03 FC A5 A5
 				39 00 00 00 00 00 02 B0 0B
 				39 00 00 00 00 00 03 D8 50 00
 				39 00 00 00 00 00 02 53 23
@@ -399,7 +426,8 @@
 			];
 			mi,mdss-dsi-crc-off-command-state = "dsi_hs_mode";
 		};
-		timing@1{
+
+		timing@1 {
 			mi,mdss-dsi-dimmingon-command = [39 01 00 00 00 00 02 53 28];
 			mi,mdss-dsi-dimmingon-command-state = "dsi_hs_mode";
 			mi,mdss-dsi-dimmingoff-command = [39 01 00 00 00 00 02 53 20];
@@ -420,6 +448,10 @@
 				05 01 00 00 00 00 02 28 00
 				39 00 00 00 00 00 03 F0 5A 5A
 				39 00 00 00 00 00 02 60 00
+				39 00 00 00 00 00 03 FC 5A 5A
+				39 00 00 00 00 00 02 B0 16
+				39 00 00 00 00 00 02 D1 2E
+				39 00 00 00 00 00 03 FC A5 A5
 				39 00 00 00 00 00 02 B0 0B
 				39 00 00 00 00 00 03 D8 50 00
 				39 00 00 00 00 00 02 53 22
@@ -430,6 +462,10 @@
 				05 01 00 00 00 00 02 28 00
 				39 00 00 00 00 00 03 F0 5A 5A
 				39 00 00 00 00 00 02 60 00
+				39 00 00 00 00 00 03 FC 5A 5A
+				39 00 00 00 00 00 02 B0 16
+				39 00 00 00 00 00 02 D1 2E
+				39 00 00 00 00 00 03 FC A5 A5
 				39 00 00 00 00 00 02 B0 0B
 				39 00 00 00 00 00 03 D8 50 00
 				39 00 00 00 00 00 02 53 23

--- a/arch/arm64/boot/dts/vendor/qcom/dsi-panel-k11a-38-08-0a-dsc-cmd.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/dsi-panel-k11a-38-08-0a-dsc-cmd.dtsi
@@ -61,7 +61,7 @@
 				qcom,mdss-dsi-v-bottom-border = <0>;
 				qcom,mdss-dsi-panel-clockrate = <1100000000>;
 				qcom,mdss-dsi-panel-jitter = <0x5 0x1>;
-				qcom,mdss-mdp-transfer-time-us = <14000>;
+				qcom,mdss-mdp-transfer-time-us = <7000>;
 				qcom,mdss-dsi-on-command = [
 					/* 1 Sleep Out */
 					05 01 00 00 0A 00 02 11 00            /* Sleep Out */

--- a/arch/arm64/boot/dts/vendor/qcom/kona-sde-display.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/kona-sde-display.dtsi
@@ -1346,14 +1346,15 @@
 	qcom,mdss-dsi-clk-strength = <0xFF>;
 	qcom,mdss-dsi-display-timings {
 		/* 120 Hz */
-		timing@0{
+		timing@0 {
 			qcom,mdss-dsi-panel-phy-timings = [00 24 0A 0A 26 24 0A
 				0A 06 02 04 00 1E 1A];
 			qcom,display-topology = <1 1 1>;
 			qcom,default-topology-index = <0>;
 		};
+
 		/* 60 Hz */
-		timing@1{
+		timing@1 {
 			qcom,mdss-dsi-panel-phy-timings = [00 24 0A 0A 26 24 0A
 				0A 06 02 04 00 1E 1A];
 			qcom,display-topology = <1 1 1>;

--- a/arch/arm64/boot/dts/vendor/qcom/kona.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/kona.dtsi
@@ -772,6 +772,7 @@
 		clock-names = "core_clk";
 
 		qcom,coresight-jtagmm-cpu = <&CPU0>;
+		status = "disabled";
 	};
 
 	jtag_mm1: jtagmm@7140000 {
@@ -783,6 +784,7 @@
 		clock-names = "core_clk";
 
 		qcom,coresight-jtagmm-cpu = <&CPU1>;
+		status = "disabled";
 	};
 
 	jtag_mm2: jtagmm@7240000 {
@@ -794,6 +796,7 @@
 		clock-names = "core_clk";
 
 		qcom,coresight-jtagmm-cpu = <&CPU2>;
+		status = "disabled";
 	};
 
 	jtag_mm3: jtagmm@7340000 {
@@ -805,6 +808,7 @@
 		clock-names = "core_clk";
 
 		qcom,coresight-jtagmm-cpu = <&CPU3>;
+		status = "disabled";
 	};
 
 	jtag_mm4: jtagmm@7440000 {
@@ -816,6 +820,7 @@
 		clock-names = "core_clk";
 
 		qcom,coresight-jtagmm-cpu = <&CPU4>;
+		status = "disabled";
 	};
 
 	jtag_mm5: jtagmm@7540000 {
@@ -827,6 +832,7 @@
 		clock-names = "core_clk";
 
 		qcom,coresight-jtagmm-cpu = <&CPU5>;
+		status = "disabled";
 	};
 
 	jtag_mm6: jtagmm@7640000 {
@@ -838,6 +844,7 @@
 		clock-names = "core_clk";
 
 		qcom,coresight-jtagmm-cpu = <&CPU6>;
+		status = "disabled";
 	};
 
 	jtag_mm7: jtagmm@7740000 {
@@ -849,6 +856,7 @@
 		clock-names = "core_clk";
 
 		qcom,coresight-jtagmm-cpu = <&CPU7>;
+		status = "disabled";
 	};
 
 	qcom,devfreq-l3 {
@@ -5165,7 +5173,6 @@
 #include "kona-pinctrl.dtsi"
 #include "kona-smp2p.dtsi"
 #include "kona-usb.dtsi"
-#include "kona-coresight.dtsi"
 #include "kona-sde.dtsi"
 #include "kona-sde-pll.dtsi"
 #include "msm-rdbg.dtsi"

--- a/techpack/display/msm/dsi/dsi_display.c
+++ b/techpack/display/msm/dsi/dsi_display.c
@@ -1086,9 +1086,11 @@ int dsi_display_set_power(struct drm_connector *connector,
 		mi_cfg->in_aod = true;
 		mi_drm_notifier_call_chain(MI_DRM_EARLY_EVENT_BLANK, &notify_data);
 		rc = dsi_panel_set_lp2(display->panel);
-		mi_cfg->unset_doze_brightness=DOZE_BRIGHTNESS_HBM;
-		if (mi_cfg->unset_doze_brightness)
-			dsi_panel_set_doze_brightness(display->panel,
+		if (mi_cfg->last_bl_level>70)
+			mi_cfg->unset_doze_brightness=DOZE_BRIGHTNESS_HBM;
+		else
+			mi_cfg->unset_doze_brightness=DOZE_BRIGHTNESS_LBM;
+		dsi_panel_set_doze_brightness(display->panel,
 				mi_cfg->unset_doze_brightness, true);
 		mi_drm_notifier_call_chain(MI_DRM_EVENT_BLANK, &notify_data);
 		break;


### PR DESCRIPTION
120Hz doesn't work with current device tree because one of the transfer times wasn't changed.